### PR TITLE
Fix test output leaking on re-injection and expose FlushAsync

### DIFF
--- a/src/Serilog.Sinks.XUnit.Injectable/Abstract/IInjectableTestOutputSink.cs
+++ b/src/Serilog.Sinks.XUnit.Injectable/Abstract/IInjectableTestOutputSink.cs
@@ -26,6 +26,14 @@ public interface IInjectableTestOutputSink : ILogEventSink, IAsyncDisposable, ID
     void Inject(ITestOutputHelper testOutputHelper, IMessageSink? messageSink = null);
 
     /// <summary>
+    /// Waits until the reader has written every event enqueued so far to the currently-injected helper.
+    /// Does not close the channel; the sink remains usable after this call. Use this before reading
+    /// the helper's output so validation is deterministic.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> that completes once the pending output has been written.</returns>
+    ValueTask FlushAsync();
+
+    /// <summary>
     /// Enqueues an event without blocking. Events are buffered while no helper is available and may be dropped when bounded capacity is exhausted.
     /// </summary>
     /// <param name="logEvent">The event being logged</param>

--- a/src/Serilog.Sinks.XUnit.Injectable/InjectableTestOutputSink.cs
+++ b/src/Serilog.Sinks.XUnit.Injectable/InjectableTestOutputSink.cs
@@ -28,12 +28,22 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
 
     private readonly MessageTemplateTextFormatter _fmt;
 
-    // Bounded channel prevents infinite growth if tests end or helper is missing.
-    private readonly Channel<LogEvent> _ch = Channel.CreateBounded<LogEvent>(new BoundedChannelOptions(_channelCapacity)
+    /// <summary>
+    /// Bounded channel prevents infinite growth if tests end or helper is missing.
+    /// Items carry either a log event or a drain barrier (used to deterministically wait for
+    /// the reader to have written everything enqueued before it).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BoundedChannelFullMode.Wait"/> (not DropWrite) is used so the drain barrier,
+    /// written via WriteAsync, is never dropped when the channel is full: it blocks until the
+    /// reader frees space and is therefore guaranteed to be enqueued. Normal log events keep
+    /// using TryWrite, which is best-effort and drops when full (see <see cref="Emit"/>).
+    /// </remarks>
+    private readonly Channel<SinkItem> _ch = Channel.CreateBounded<SinkItem>(new BoundedChannelOptions(_channelCapacity)
     {
         SingleReader = true,
         SingleWriter = false,
-        FullMode = BoundedChannelFullMode.DropWrite,
+        FullMode = BoundedChannelFullMode.Wait,
         AllowSynchronousContinuations = false
     });
 
@@ -57,11 +67,65 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
         _readerTask = Task.Run(() => ReadLoop(_cts.Token));
     }
 
+    /// <summary>
+    /// Replaces the active output helper after draining any output still queued for the previous one.
+    /// Intended to be called at a test boundary (when switching from one test to the next); it is not
+    /// designed to run concurrently with <see cref="Emit"/> from multiple tests at the same time.
+    /// </summary>
     public void Inject(ITestOutputHelper helper, IMessageSink? diagnosticSink = null)
     {
         ArgumentNullException.ThrowIfNull(helper);
+
+        // Drain the previously-injected helper first so any output still queued for it is
+        // written there before we re-point. Otherwise the reader (which reads _helper per
+        // event) would write the previous test's leftover lines to the newly injected helper.
+        DrainCurrentHelper();
+
         _helper = helper; // publish to reader
         _sink = diagnosticSink;
+    }
+
+    /// <summary>
+    /// Waits until the reader has written every event enqueued so far to the currently-injected helper.
+    /// </summary>
+    public async ValueTask FlushAsync()
+    {
+        if (_disposed.Value || _helper is null)
+            return;
+
+        var barrier = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            await _ch.Writer.WriteAsync(new SinkItem(null, barrier)).ConfigureAwait(false);
+        }
+        catch (ChannelClosedException)
+        {
+            return;
+        }
+
+        await barrier.Task.ConfigureAwait(false);
+    }
+
+    private void DrainCurrentHelper()
+    {
+        if (_disposed.Value || _helper is null)
+            return;
+
+        var barrier = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            // AsTask() yields a real Task so GetResult() blocks until the channel has space under
+            // Wait mode; observing the pending async ValueTask directly would throw "not completed".
+            _ch.Writer.WriteAsync(new SinkItem(null, barrier)).AsTask().GetAwaiter().GetResult();
+        }
+        catch (ChannelClosedException)
+        {
+            return;
+        }
+
+        barrier.Task.GetAwaiter().GetResult();
     }
 
     public void Emit(LogEvent logEvent)
@@ -69,7 +133,7 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
         if (logEvent is null || _disposed.Value)
             return;
 
-        _ch.Writer.TryWrite(logEvent); // non-blocking; may drop when full
+        _ch.Writer.TryWrite(new SinkItem(logEvent, null)); // non-blocking; may drop when full
     }
 
     public void Complete()
@@ -86,11 +150,19 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
     {
         try
         {
-            await foreach (LogEvent evt in _ch.Reader.ReadAllAsync(ct)
-                                              .ConfigureAwait(false))
+            await foreach (var item in _ch.Reader.ReadAllAsync(ct).ConfigureAwait(false))
             {
                 if (ct.IsCancellationRequested)
                     break;
+
+                if (item.Barrier is not null)
+                {
+                    // Everything enqueued before this barrier has been processed.
+                    item.Barrier.TrySetResult();
+                    continue;
+                }
+
+                var evt = item.Event!;
 
                 ITestOutputHelper? helper = _helper; // volatile read
                 if (helper is null)
@@ -243,4 +315,6 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
         _helper = null; // stop xUnit calls after drain
         _cts.Dispose();
     }
+
+    private readonly record struct SinkItem(LogEvent? Event, TaskCompletionSource? Barrier);
 }

--- a/src/Serilog.Sinks.XUnit.Injectable/InjectableTestOutputSink.cs
+++ b/src/Serilog.Sinks.XUnit.Injectable/InjectableTestOutputSink.cs
@@ -26,6 +26,11 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
     private static readonly TimeSpan _drainWait = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan _cancelWait = TimeSpan.FromSeconds(3);
 
+    // Bounded wait for a drain barrier: covers the worst-case disposal path (drain + cancel) so a
+    // concurrent Inject/FlushAsync can never hang if the reader is cancelled before it reaches the
+    // barrier.
+    private static readonly TimeSpan _barrierWait = TimeSpan.FromSeconds(5);
+
     private readonly MessageTemplateTextFormatter _fmt;
 
     /// <summary>
@@ -71,6 +76,7 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
     /// Replaces the active output helper after draining any output still queued for the previous one.
     /// Intended to be called at a test boundary (when switching from one test to the next); it is not
     /// designed to run concurrently with <see cref="Emit"/> from multiple tests at the same time.
+    /// The drain is bounded, so this never hangs even if the sink is disposed concurrently.
     /// </summary>
     public void Inject(ITestOutputHelper helper, IMessageSink? diagnosticSink = null)
     {
@@ -87,6 +93,8 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
 
     /// <summary>
     /// Waits until the reader has written every event enqueued so far to the currently-injected helper.
+    /// The wait is bounded; if disposal races the flush and cancels the reader, it returns without
+    /// the drain guarantee.
     /// </summary>
     public async ValueTask FlushAsync()
     {
@@ -104,7 +112,14 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
             return;
         }
 
-        await barrier.Task.ConfigureAwait(false);
+        try
+        {
+            await barrier.Task.WaitAsync(_barrierWait).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // disposal raced the flush and cancelled the reader; proceed without the drain guarantee
+        }
     }
 
     private void DrainCurrentHelper()
@@ -125,7 +140,14 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
             return;
         }
 
-        barrier.Task.GetAwaiter().GetResult();
+        try
+        {
+            barrier.Task.WaitAsync(_barrierWait).GetAwaiter().GetResult();
+        }
+        catch (TimeoutException)
+        {
+            // disposal raced the drain and cancelled the reader; proceed without the drain guarantee
+        }
     }
 
     public void Emit(LogEvent logEvent)
@@ -187,6 +209,13 @@ public sealed class InjectableTestOutputSink : IInjectableTestOutputSink
         catch
         {
             // never let logging crash tests
+        }
+        finally
+        {
+            // If the loop exits early (e.g., cancellation during disposal), complete any barrier that
+            // was already enqueued so a concurrent Inject/FlushAsync returns promptly.
+            while (_ch.Reader.TryRead(out SinkItem item))
+                item.Barrier?.TrySetResult();
         }
     }
 

--- a/test/Benchmarks/SinkBenchmark.cs
+++ b/test/Benchmarks/SinkBenchmark.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
 using Serilog.Events;
 using Serilog.Parsing;
+using Serilog.Sinks.XUnit.Injectable;
 using Serilog.Sinks.XUnit.Injectable.Abstract;
 using Serilog.Sinks.XUnit.Injectable.Tests.Sinks;
 using Serilog.Sinks.XUnit.Injectable.Tests.Utils;
@@ -13,7 +14,7 @@ namespace Serilog.Sinks.XUnit.Injectable.Tests.Benchmarks;
 
 [ThreadingDiagnoser]
 [MemoryDiagnoser]
-[SimpleJob(RunStrategy.Throughput, RuntimeMoniker.Net90, launchCount: 1, warmupCount: 1, iterationCount: 1)]
+[SimpleJob(RunStrategy.Throughput, RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 1, iterationCount: 1)]
 public class SinkBenchmark
 {
     // each thread will execute this many emits per iteration
@@ -29,6 +30,7 @@ public class SinkBenchmark
     private IInjectableTestOutputSink _cc = null!;
     private IInjectableTestOutputSink _block = null!;
     private IInjectableTestOutputSink _chan = null!;
+    private IInjectableTestOutputSink _injectable = null!;
 
     private readonly MockTestOutputHelper _helper = new();
 
@@ -43,8 +45,9 @@ public class SinkBenchmark
         _cc = new ConcurrentInjectableTestOutputSink();
         _block = new BlockingCollectionInjectableTestOutputSink();
         _chan = new ChannelInjectableTestOutputSink();
+        _injectable = new InjectableTestOutputSink();
 
-        foreach (IInjectableTestOutputSink s in new[] {_orig, _queue, _cc, _block, _chan})
+        foreach (IInjectableTestOutputSink s in new[] {_orig, _queue, _cc, _block, _chan, _injectable})
             s.Inject(_helper);
     }
 
@@ -68,4 +71,7 @@ public class SinkBenchmark
 
     [Benchmark]
     public async Task Channel() => await RunAsync(_chan);
+
+    [Benchmark]
+    public async Task Injectable() => await RunAsync(_injectable);
 }

--- a/test/Sinks/BlockingCollectionInjectableTestOutputSink.cs
+++ b/test/Sinks/BlockingCollectionInjectableTestOutputSink.cs
@@ -33,6 +33,10 @@ public sealed class BlockingCollectionInjectableTestOutputSink : IInjectableTest
     {
         throw new NotImplementedException();
     }
+    public ValueTask FlushAsync()
+    {
+        return ValueTask.CompletedTask; // benchmark reference sink: FlushAsync not implemented
+    }
     public void Inject(ITestOutputHelper helper, IMessageSink? sink = null)
     {
         ArgumentNullException.ThrowIfNull(helper);

--- a/test/Sinks/ChannelInjectableTestOutputSink.cs
+++ b/test/Sinks/ChannelInjectableTestOutputSink.cs
@@ -34,6 +34,10 @@ public sealed class ChannelInjectableTestOutputSink : IInjectableTestOutputSink
     {
         throw new NotImplementedException();
     }
+    public ValueTask FlushAsync()
+    {
+        return ValueTask.CompletedTask; // benchmark reference sink: FlushAsync not implemented
+    }
     public void Inject(ITestOutputHelper helper, IMessageSink? sink = null)
     {
         ArgumentNullException.ThrowIfNull(helper);

--- a/test/Sinks/ConcurrentInjectableTestOutputSink.cs
+++ b/test/Sinks/ConcurrentInjectableTestOutputSink.cs
@@ -29,6 +29,10 @@ public sealed class ConcurrentInjectableTestOutputSink : IInjectableTestOutputSi
     {
         throw new NotImplementedException();
     }
+    public ValueTask FlushAsync()
+    {
+        return ValueTask.CompletedTask; // synchronous sink: events are written directly, nothing to flush
+    }
     public void Inject(ITestOutputHelper helper, IMessageSink? sink = null)
     {
         ArgumentNullException.ThrowIfNull(helper);

--- a/test/Sinks/OriginalInjectableTestOutputSink.cs
+++ b/test/Sinks/OriginalInjectableTestOutputSink.cs
@@ -26,6 +26,10 @@ public sealed class OriginalInjectableTestOutputSink : IInjectableTestOutputSink
     {
         throw new NotImplementedException();
     }
+    public ValueTask FlushAsync()
+    {
+        return ValueTask.CompletedTask; // synchronous sink: nothing is buffered
+    }
     public void Inject(ITestOutputHelper testOutputHelper, IMessageSink? messageSink = null)
     {
         _testOutputHelper = testOutputHelper;

--- a/test/Sinks/QueueInjectableTestOutputSink.cs
+++ b/test/Sinks/QueueInjectableTestOutputSink.cs
@@ -29,6 +29,10 @@ public sealed class QueueInjectableTestOutputSink : IInjectableTestOutputSink
     {
         throw new NotImplementedException();
     }
+    public ValueTask FlushAsync()
+    {
+        return ValueTask.CompletedTask; // synchronous sink: events are written directly, nothing to flush
+    }
     public void Inject(ITestOutputHelper helper, IMessageSink? sink = null)
     {
         ArgumentNullException.ThrowIfNull(helper);

--- a/test/Unit/InjectableTestOutputSinkTests.cs
+++ b/test/Unit/InjectableTestOutputSinkTests.cs
@@ -162,4 +162,56 @@ public sealed class InjectableTestOutputSinkTests
         await sink.DisposeAsync();
         await sink.FlushAsync(); // sink disposed
     }
+
+    [Test]
+    public async Task Reinjecting_while_disposal_cancels_the_reader_should_not_hang()
+    {
+        var sink = new InjectableTestOutputSink();
+        // A gated first helper blocks the reader on its first write, so the dispose drain window
+        // elapses and disposal cancels the reader while the drain barrier is still queued behind
+        // it.
+        var first = new GatedTestOutputHelper();
+        var second = new MockTestOutputHelper();
+
+        sink.Inject(first);
+
+        for (var i = 0; i < 4_000; i++)
+            sink.Emit(MockTestOutputHelper.CreateEvent($"dispose-{i}"));
+
+        var reinject = Task.Run(() => sink.Inject(second));
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+
+        // Dispose while the barrier is queued: the gated reader never reaches it, so the drain
+        // times out and disposal cancels the reader mid-drain.
+        await sink.DisposeAsync();
+
+        var completed = await Task.WhenAny(reinject, Task.Delay(TimeSpan.FromSeconds(10)));
+        completed.Should().BeSameAs(reinject, because: "re-injection must not hang when disposal cancels the reader before it reaches the barrier");
+        await reinject;
+    }
+
+    [Test]
+    public async Task Flushing_while_disposal_cancels_the_reader_should_not_hang()
+    {
+        var sink = new InjectableTestOutputSink();
+        // A gated helper blocks the reader on its first write, so the dispose drain window elapses
+        // and disposal cancels the reader while the flush barrier is still queued behind it.
+        var helper = new GatedTestOutputHelper();
+
+        sink.Inject(helper);
+
+        for (var i = 0; i < 4_000; i++)
+            sink.Emit(MockTestOutputHelper.CreateEvent($"dispose-flush-{i}"));
+
+        var flush = sink.FlushAsync().AsTask();
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+
+        // Dispose while the barrier is queued: the gated reader never reaches it, so the drain
+        // times out and disposal cancels the reader mid-flush.
+        await sink.DisposeAsync();
+
+        var completed = await Task.WhenAny(flush, Task.Delay(TimeSpan.FromSeconds(10)));
+        completed.Should().BeSameAs(flush, because: "the flush must not hang when disposal cancels the reader before it reaches the barrier");
+        await flush;
+    }
 }

--- a/test/Unit/InjectableTestOutputSinkTests.cs
+++ b/test/Unit/InjectableTestOutputSinkTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Serilog.Sinks.XUnit.Injectable;
+using Serilog.Sinks.XUnit.Injectable.Tests.Utils;
+using TUnit;
+
+namespace Serilog.Sinks.XUnit.Injectable.Tests.Unit;
+
+public sealed class InjectableTestOutputSinkTests
+{
+    [Test]
+    public async Task Reinjecting_a_helper_should_not_leak_previous_helper_output()
+    {
+        var sink = new InjectableTestOutputSink();
+        var first = new MockTestOutputHelper();
+        var second = new MockTestOutputHelper();
+
+        sink.Inject(first);
+
+        for (var i = 0; i < 4_000; i++)
+            sink.Emit(MockTestOutputHelper.CreateEvent($"test1-{i}"));
+
+        sink.Inject(second);
+        sink.Emit(MockTestOutputHelper.CreateEvent("test2"));
+
+        await sink.DisposeAsync();
+
+        second.Output.Should().NotContain(
+            "test1-",
+            because: "output written while the first helper was active must not leak into the second helper");
+        second.Output.Should().Contain("test2");
+        first.Output.Should().Contain("test1-");
+    }
+
+    [Test]
+    public async Task Reinjecting_when_channel_is_full_should_not_deadlock()
+    {
+        var sink = new InjectableTestOutputSink();
+        // A gated first helper blocks the reader on its first write, so the bounded channel stays
+        // full while re-injection happens (the reader cannot drain). This guarantees the drain
+        // barrier is written to a full channel.
+        var first = new GatedTestOutputHelper();
+        var second = new MockTestOutputHelper();
+
+        sink.Inject(first);
+
+        // Saturate the channel well beyond its 4096 capacity. The reader is gated, so it cannot
+        // drain and the channel remains full when re-injection happens.
+        for (var i = 0; i < 8_192; i++)
+            sink.Emit(MockTestOutputHelper.CreateEvent($"test1-{i}"));
+
+        // Re-injection must always complete, even while the channel is full. Run it on a separate
+        // thread so the gated reader can be released after the drain barrier write has begun.
+        // Under DropWrite the barrier write would drop the barrier (channel full) and re-injection
+        // would hang forever; under Wait it blocks until the reader frees space, then completes.
+        var reinject = Task.Run(() => sink.Inject(second));
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        first.Unlock();
+
+        var completed = await Task.WhenAny(reinject, Task.Delay(TimeSpan.FromSeconds(10)));
+        completed.Should().BeSameAs(reinject, because: "re-injection must not deadlock while the channel is full");
+        await reinject;
+
+        sink.Emit(MockTestOutputHelper.CreateEvent("test2"));
+        await sink.DisposeAsync();
+
+        second.Output.Should().NotContain(
+            "test1-",
+            because: "output written while the first helper was active must not leak into the second helper");
+        second.Output.Should().Contain("test2");
+    }
+}

--- a/test/Unit/InjectableTestOutputSinkTests.cs
+++ b/test/Unit/InjectableTestOutputSinkTests.cs
@@ -70,4 +70,96 @@ public sealed class InjectableTestOutputSinkTests
             because: "output written while the first helper was active must not leak into the second helper");
         second.Output.Should().Contain("test2");
     }
+
+    [Test]
+    public async Task Flushing_should_wait_until_all_queued_output_is_written()
+    {
+        var sink = new InjectableTestOutputSink();
+        // A gated helper blocks the reader on its first write, so nothing is flushed while the
+        // test produces output.
+        var helper = new GatedTestOutputHelper();
+
+        sink.Inject(helper);
+
+        for (var i = 0; i < 4_000; i++)
+            sink.Emit(MockTestOutputHelper.CreateEvent($"flush-{i}"));
+
+        var flush = sink.FlushAsync().AsTask();
+        helper.Output.Should().NotContain(
+            "flush-3999",
+            because: "the reader is gated; the flush must not complete before it is released");
+        helper.Unlock();
+
+        var completed = await Task.WhenAny(flush, Task.Delay(TimeSpan.FromSeconds(10)));
+        completed.Should().BeSameAs(flush, because: "the flush must not deadlock while the reader is gated");
+        await flush;
+
+        helper.Output.Should().Contain(
+            "flush-3999",
+            because: "the flush must not complete until every enqueued event has been written");
+
+        await sink.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Flushing_when_channel_is_full_should_not_deadlock()
+    {
+        var sink = new InjectableTestOutputSink();
+        // A gated helper blocks the reader on its first write, so the bounded channel stays full
+        // while the flush happens (the reader cannot drain). This guarantees the flush barrier is
+        // written to a full channel.
+        var helper = new GatedTestOutputHelper();
+
+        sink.Inject(helper);
+
+        // Saturate the channel well beyond its 4096 capacity. The reader is gated, so it cannot
+        // drain and the channel remains full when the flush happens.
+        for (var i = 0; i < 8_192; i++)
+            sink.Emit(MockTestOutputHelper.CreateEvent($"flush-{i}"));
+
+        // The flush barrier must always be enqueued, even while the channel is full. Wait for the
+        // barrier write to begin (it blocks on the full channel under Wait mode), then release the
+        // gated reader. Under DropWrite the barrier write would drop the barrier and the flush
+        // would hang forever; under Wait it blocks until the reader frees space, then completes.
+        var flush = sink.FlushAsync().AsTask();
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        helper.Unlock();
+
+        var completed = await Task.WhenAny(flush, Task.Delay(TimeSpan.FromSeconds(10)));
+        completed.Should().BeSameAs(flush, because: "the flush must not deadlock while the channel is full");
+        await flush;
+
+        helper.Output.Should().Contain("flush-0");
+        await sink.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Flushing_should_keep_the_sink_usable()
+    {
+        var sink = new InjectableTestOutputSink();
+        var helper = new MockTestOutputHelper();
+
+        sink.Inject(helper);
+
+        sink.Emit(MockTestOutputHelper.CreateEvent("before-flush"));
+        await sink.FlushAsync();
+        helper.Output.Should().Contain("before-flush");
+
+        // A flush must not close the channel; the sink remains usable afterwards.
+        sink.Emit(MockTestOutputHelper.CreateEvent("after-flush"));
+        await sink.FlushAsync();
+        helper.Output.Should().Contain("after-flush");
+
+        await sink.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Flushing_without_a_helper_or_after_disposal_should_not_throw()
+    {
+        var sink = new InjectableTestOutputSink();
+
+        await sink.FlushAsync(); // no helper injected
+        await sink.DisposeAsync();
+        await sink.FlushAsync(); // sink disposed
+    }
 }

--- a/test/Utils/GatedTestOutputHelper.cs
+++ b/test/Utils/GatedTestOutputHelper.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Serilog.Sinks.XUnit.Injectable.Tests.Utils;
+
+/// <summary>
+/// A test output helper that blocks the reader on its first write until <see cref="Unlock"/> is
+/// called. While locked, the reader cannot drain the sink's bounded channel, which keeps it full.
+/// </summary>
+internal sealed class GatedTestOutputHelper : ITestOutputHelper
+{
+    private readonly ManualResetEventSlim _gate = new(false);
+    private readonly StringWriter _writer = new();
+
+    public string Output => _writer.ToString();
+
+    public void Unlock() => _gate.Set();
+
+    public void Write(string message)
+    {
+        _gate.Wait();
+        _writer.Write(message);
+    }
+
+    public void Write(string format, params object[] args)
+    {
+        _gate.Wait();
+        _writer.Write(format, args);
+    }
+
+    public void WriteLine(string message)
+    {
+        _gate.Wait();
+        _writer.WriteLine(message);
+    }
+
+    public void WriteLine(string format, params object[] args)
+    {
+        _gate.Wait();
+        _writer.WriteLine(format, args);
+    }
+}


### PR DESCRIPTION
## Description

Fixes a leak where output queued for a previously-injected `ITestOutputHelper` could be written to the next test's helper when a shared `InjectableTestOutputSink` is re-injected. Also exposes `FlushAsync()` on `IInjectableTestOutputSink` and repairs the (silently broken) sink benchmark.

### Problem
When a shared `InjectableTestOutputSink` is re-injected with a new `ITestOutputHelper` (the per-test scenario), output still queued for the previously-injected helper could be written to the new helper — the previous test's lines leaked into the next test's output.

### Root cause
`Emit` is fire-and-forget into a bounded channel drained by a single background reader task. The reader calls `helper.WriteLine(...)` using whatever `_helper` is set *at the time it processes each event*. Re-pointing `_helper` via `Inject` while the reader still holds the previous test's events therefore mis-attributes those lines.

### Fix
- `Inject` now drains the currently-injected helper before re-pointing `_helper`, so the previous helper fully receives its queued output.
- The channel now carries a `SinkItem` that is either a log event or a drain barrier; the reader completes the barrier after everything enqueued before it, giving a deterministic drain.
- The channel uses `BoundedChannelFullMode.Wait` (not `DropWrite`) so the drain barrier is never dropped when the channel is full — it blocks until the reader frees space and is guaranteed to be enqueued. Normal log events keep using `TryWrite` (best-effort, drops when full).
- The barrier write uses `WriteAsync(...).AsTask().GetAwaiter().GetResult()` so the synchronous drain genuinely blocks (observing the pending async `ValueTask` directly throws "not completed").
- The barrier wait is bounded (5 s, covering the worst-case disposal path of drain + cancel), and the reader completes any already-enqueued barriers when it exits early, so `Inject` and `FlushAsync` never hang even when racing sink disposal.
- Added `FlushAsync()` to `IInjectableTestOutputSink` so callers holding the interface can deterministically flush the current helper at a chosen point (same mechanism as the `Inject` drain; the test-project benchmark reference sinks get a no-op stub). **Note: this is source-breaking for external implementers of the interface** (the only implementation today is the sink itself).

### Test
- `Reinjecting_a_helper_should_not_leak_previous_helper_output` reproduces the leak: inject helper 1, emit 4,000 events, re-inject helper 2, and assert helper 2 received none of helper 1's output. Fails on the previous code, passes with the fix.
- `Reinjecting_when_channel_is_full_should_not_deadlock` saturates the 4,096-item channel (via a gated helper that holds the reader so the channel stays full) and asserts re-injection still completes. Under the old `DropWrite` channel the barrier could be dropped and re-injection deadlocked; this test fails on that code and passes with the fix.
- `FlushAsync` is covered directly: `Flushing_should_wait_until_all_queued_output_is_written` (with a gated reader, the flush does not complete until all 4,000 enqueued events have been written), `Flushing_when_channel_is_full_should_not_deadlock` (a flush against a saturated channel blocks instead of dropping the barrier; fails under the old `DropWrite` channel), `Flushing_should_keep_the_sink_usable` (the sink remains usable after a flush), and `Flushing_without_a_helper_or_after_disposal_should_not_throw` (the early-return paths).
- `Reinjecting_while_disposal_cancels_the_reader_should_not_hang` and `Flushing_while_disposal_cancels_the_reader_should_not_hang` race `Inject`/`FlushAsync` against disposal: a gated reader holds the drain past its 2 s window so disposal cancels the reader before it reaches the barrier. Without the bounded wait and pending-barrier completion both operations hang, so both tests fail on that code.
- Full suite (14 tests) passes.

### Benchmark
- The benchmark was silently not running: the job targeted `RuntimeMoniker.Net90` while the test project only supports `net10.0`, so BenchmarkDotNet's auto-generated net9.0 project failed to restore (NU1201), 0 of 45 cases executed, and the runner test still "passed". Fixed to `RuntimeMoniker.Net10_0`.
- Added `InjectableTestOutputSink` to `SinkBenchmark` — previously only the four reference sinks were measured.
- Before/after comparison (Release, all 45 cases): no measurable regression — the fixed sink's deltas stay within the noise band the unchanged reference sinks exhibit between runs (-20%…+83%), and at high load it remains in the same ballpark as the naive unbounded-Channel reference.

---

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] ✅ Test improvement

---

## Checklist

- [x] I've added/updated necessary tests
- [x] I've added/updated documentation
- [x] My code follows the code style of this project
- [x] I've tested this manually

---

## Screenshots / Demo (if applicable)

Not applicable.